### PR TITLE
[PI01-1212] Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
 


### PR DESCRIPTION
- Replace the two mutable tag references in lint-prettier.yml with 40-character commit SHAs
- actions/checkout v3.7.0, actions/setup-node v3.9.1
- Pinned at the current v3 major; moving these onto v6 is deliberately out of scope
- Versions are unchanged, so CI behaviour is identical; this is a pinning-only change