### PR TITLE
[PI01-1244][FIX] Enforce browser security headers on homepage

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()


### PR DESCRIPTION
- add Cloudflare Pages headers for all homepage routes
- prevent framing and MIME sniffing
- restrict referrer data and unnecessary browser capabilities